### PR TITLE
upgraded Thor version to 0.19.1

### DIFF
--- a/honor_codes.gemspec
+++ b/honor_codes.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w{lib}
 
-  spec.add_runtime_dependency 'thor', '~> 0.18.1'
+  spec.add_runtime_dependency 'thor', '~> 0.19.1'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Robbie:
Upgrading to Rails 4.2 requires a compatible version (0.19.1) of Thor plugin. Please merge the pull request.
Thanks.

Prakash Teli
Alpine Data Labs.
